### PR TITLE
Fix dependency definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the `SwiftKueryPostgreSQL` package to the dependencies within your applicati
 Add `SwiftKueryPostgreSQL` to application's dependencies:
 
 ```swift
-.target(name: "Application", dependencies: ["SwiftKueryPostgreSQL"]),
+.target(name: "Application", dependencies: [.product(name: "SwiftKueryPostgreSQL", package: "Swift-Kuery-PostgreSQL")]),
 ```
 
 #### Import package


### PR DESCRIPTION
Dependency cannot be simply used as 
  `SwiftKueryPostgreSQL1
but must be written as 
  `.product(name: "SwiftKueryPostgreSQL", package: "Swift-Kuery-PostgreSQL")'